### PR TITLE
Modify gateway/server.go to catch up with the latest version of grpc-gateway

### DIFF
--- a/gateway/server.go
+++ b/gateway/server.go
@@ -12,7 +12,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 
-	"github.com/gengo/grpc-gateway/runtime"
+	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/k2wanko/grpc-pipe"
 )
 
@@ -156,7 +156,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) Request(ctx context.Context) *http.Request {
-	md, _ := metadata.FromContext(ctx)
+	md, _ := metadata.FromIncomingContext(ctx)
 	if md == nil {
 		return nil
 	}


### PR DESCRIPTION
Hi @k2wanko, I just came across your project when I was playing with grpc-gateway and GAE/Go. I found it could be useful for my toy project but I found some things were outdated. So I made a patch you might be interested in as well to catch up with the latest version of grpc-gateway.

Of course I can fork your repo and maintain my own repo but I thought it could be useful for others and I just share my patch.

Thanks for your interesting project!

------

This patch replaces the obsolete package and the function symbol in
server.go as follow to make it work with the latest version of
grpc-gateway:

- github.com/gengo/grpc-gateway is now moved to
  github.com/grpc-ecosystem/grpc-gateway
- "google.golang.org/grpc/metadata".FromContext is deprecated and
  replaced with "google.golang.org/grpc/metadata".FromIncomingContext

Signed-off-by: Taku Fukushima <f.tac.mac@gmail.com>